### PR TITLE
Support to read bootstrap server config when it is defined as a list

### DIFF
--- a/src/main/java/reactor/kafka/receiver/ReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/ReceiverOptions.java
@@ -570,7 +570,15 @@ public interface ReceiverOptions<K, V> {
      */
     @NonNull
     default String bootstrapServers() {
-        return (String) Objects.requireNonNull(consumerProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+        Object bootstrapServers = Objects.requireNonNull(consumerProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+
+        if (bootstrapServers instanceof List) {
+            @SuppressWarnings("unchecked")
+            List<String> listOfBootstrapServers = (List<String>) bootstrapServers;
+            return String.join(",", listOfBootstrapServers);
+        }
+
+        return (String) bootstrapServers;
     }
 
     /**

--- a/src/main/java/reactor/kafka/sender/SenderOptions.java
+++ b/src/main/java/reactor/kafka/sender/SenderOptions.java
@@ -19,6 +19,7 @@ package reactor.kafka.sender;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
+import java.util.List;
 import java.util.Properties;
 
 import javax.naming.AuthenticationException;
@@ -286,7 +287,15 @@ public interface SenderOptions<K, V> {
      */
     @NonNull
     default String bootstrapServers() {
-        return (String) Objects.requireNonNull(producerProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
+        Object bootstrapServers = Objects.requireNonNull(producerProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
+
+        if (bootstrapServers instanceof List) {
+            @SuppressWarnings("unchecked")
+            List<String> listOfBootstrapServers = (List<String>) bootstrapServers;
+            return String.join(",", listOfBootstrapServers);
+        }
+
+        return (String) bootstrapServers;
     }
 
     @NonNull

--- a/src/test/java/reactor/kafka/receiver/ReceiverOptionsTest.java
+++ b/src/test/java/reactor/kafka/receiver/ReceiverOptionsTest.java
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package reactor.kafka.sender;
+package reactor.kafka.receiver;
 
-import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.junit.Test;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -28,21 +27,14 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-public class SenderOptionsTest {
-
-    @Test
-    public void senderOptionsCloseTimeout() {
-        Map<String, Object> props = Collections.emptyMap();
-        SenderOptions<Integer, String> senderOptions = SenderOptions.create(props);
-        assertEquals(Duration.ofMillis(100), senderOptions.closeTimeout(Duration.ofMillis(100)).closeTimeout());
-    }
+public class ReceiverOptionsTest {
 
     @Test
     public void getBootstrapServersFromSingleServerList() {
         Map<String, Object> producerProperties = new HashMap<>();
-        producerProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, Collections.singletonList("localhost:9092"));
+        producerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, Collections.singletonList("localhost:9092"));
 
-        SenderOptions<Integer, String> senderOptions = SenderOptions.create(producerProperties);
+        ReceiverOptions<Integer, String> senderOptions = ReceiverOptions.create(producerProperties);
         String bootstrapServers = senderOptions.bootstrapServers();
 
         assertEquals("localhost:9092", bootstrapServers);
@@ -52,9 +44,9 @@ public class SenderOptionsTest {
     public void getBootstrapServersFromMultipleServersList() {
         Map<String, Object> producerProperties = new HashMap<>();
         List<String> serverList = Arrays.asList("localhost:9092", "localhost:9093", "localhost:9094");
-        producerProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, serverList);
+        producerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, serverList);
 
-        SenderOptions<Integer, String> senderOptions = SenderOptions.create(producerProperties);
+        ReceiverOptions<Integer, String> senderOptions = ReceiverOptions.create(producerProperties);
         String bootstrapServers = senderOptions.bootstrapServers();
 
         assertEquals("localhost:9092,localhost:9093,localhost:9094", bootstrapServers);
@@ -63,9 +55,9 @@ public class SenderOptionsTest {
     @Test
     public void getBootstrapServersFromString() {
         Map<String, Object> producerProperties = new HashMap<>();
-        producerProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        producerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
 
-        SenderOptions<Integer, String> senderOptions = SenderOptions.create(producerProperties);
+        ReceiverOptions<Integer, String> senderOptions = ReceiverOptions.create(producerProperties);
         String bootstrapServers = senderOptions.bootstrapServers();
 
         assertEquals("localhost:9092", bootstrapServers);


### PR DESCRIPTION
Resolves #374

Introduces support for reading the boot servers when the property was defined as a List and not a String.

It will avoid a class cast exception when using reactor-kafka with Spring Boot Kafka since this library configures the bootstrap servers as a list of string and not a String object as you can see on [their implementation](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java#L71).
